### PR TITLE
Use reference instead of copy so updates in applicationList

### DIFF
--- a/app/src/main/java/com/codingbad/vpntoggle/adapter/ItemsAdapter.java
+++ b/app/src/main/java/com/codingbad/vpntoggle/adapter/ItemsAdapter.java
@@ -127,7 +127,7 @@ public class ItemsAdapter extends RecyclerView.Adapter<ApplicationViewHolder> {
     }
 
     public void setItems(List<ApplicationItem> items) {
-        this.applicationList = ArrayUtils.copyFrom(items);
+        this.applicationList = items;
         notifyDataSetChanged();
     }
 


### PR DESCRIPTION
 copy reference instead of array so ApplicationStatus has the same value and updated references work.
